### PR TITLE
Made build method twig context aware

### DIFF
--- a/Builder/MainBuilder.php
+++ b/Builder/MainBuilder.php
@@ -57,10 +57,12 @@ class MainBuilder
     }
 
     /**
-     * build method
+     * Builds breadcrumbs output
+     *
+     * @param array $context Context twig variables array
      * @return mixed
      */
-    public function build()
+    public function build(array $context)
     {
         $breadcrumbs = $this->builder->build();
         $this->environment->getExtension('escaper')->setDefaultStrategy(false);
@@ -71,7 +73,7 @@ class MainBuilder
                 'mode' => $this->mode,
                 'items' => $breadcrumbs,
                 'separator' => $this->separator
-            ),
+            ) + $context,
             array('breadcrumbs')
         );
     }

--- a/Twig/BreadcrumbsExtension.php
+++ b/Twig/BreadcrumbsExtension.php
@@ -20,13 +20,13 @@ class BreadcrumbsExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'build_breadcrumbs' => new \Twig_Function_Method($this, 'buildBreadcrumbs')
+            'build_breadcrumbs' => new \Twig_Function_Method($this, 'buildBreadcrumbs', array('needs_context' => true))
         );
     }
 
-    public function buildBreadcrumbs()
+    public function buildBreadcrumbs(array $context)
     {
-        return $this->builder->build();
+        return $this->builder->build($context);
     }
 
     public function getName()


### PR DESCRIPTION
It's usefull to provide a mechanism of using context twig variables. For instance, taking movie names:
Main / Movies / Saw 5
in breadcrumbs.yml:

``` yml
Movies:
    label: Movies
    route: movies
    children:
        Movie view:
            label: movie.name
            route: movie_view
```

Then user may do some twig magic to provide twig variable variable resolving and voila.

Another way is to provide getter, wich will return only built breadcrumbs array without rendering template.
